### PR TITLE
Update IKOverlay.cpp for all uppercase alphabet

### DIFF
--- a/src/IKOverlay.cpp
+++ b/src/IKOverlay.cpp
@@ -794,10 +794,10 @@ void IKOverlay::initStdAlphabet(void) {
   col = 0;
 
   ik_report_keyboard_t const sixth_row[] = {{KEYBOARD_MODIFIER_LEFTSHIFT, 0},
-                                            {0, HID_KEY_W},
-                                            {0, HID_KEY_X},
-                                            {0, HID_KEY_Y},
-                                            {0, HID_KEY_Z},
+                                            {KEYBOARD_MODIFIER_LEFTSHIFT, HID_KEY_W},
+                                            {KEYBOARD_MODIFIER_LEFTSHIFT, HID_KEY_X},
+                                            {KEYBOARD_MODIFIER_LEFTSHIFT, HID_KEY_Y},
+                                            {KEYBOARD_MODIFIER_LEFTSHIFT, HID_KEY_Z},
                                             {KEYBOARD_MODIFIER_LEFTSHIFT, 0}};
 
   overlay.setMembraneKeyboardArr(row, col, height, width, sixth_row,


### PR DESCRIPTION
Could you have a look at this, that could be an all upper case solution to https://github.com/adafruit/Adafruit_IntelliKeys/issues/3 but totally untested.

Totally not tested (I don't really have a development environment to compile this and test).
Also I just had a quick look at the code to try to locate where it is happening.
But if you want to have everything uppercase, including `wxyz`, this could do it and answer the problem I describe in #3 .